### PR TITLE
Add a linefeed at the end of show.cacomp representation

### DIFF
--- a/R/generic_methods.R
+++ b/R/generic_methods.R
@@ -66,7 +66,7 @@ show.cacomp <- function(object){
         paste0(round(percentInertia[1], 1),
                "% Dim1, ",
                round(percentInertia[2], 1),
-               "% Dim2"))
+               "% Dim2\n"))
   }
 
 }


### PR DESCRIPTION
Add a linefeed at the end of show.cacomp representation to avoid messing up the prompt edition when it starts on the last line.